### PR TITLE
Fixed a variable naming error, where we were creating a new 'msa_len'…

### DIFF
--- a/src/MapsToMSAs.pl
+++ b/src/MapsToMSAs.pl
@@ -844,9 +844,10 @@ sub ComposeMSA
     #
     my @Disagreements = ();
     if ($num_seqs > 1) {
-	my ($msa_ref,$DisagreementsRef,$msa_len) = MinorClean(\@MSA,$num_seqs,$msa_len);
+	my ($msa_ref,$DisagreementsRef,$new_len) = MinorClean(\@MSA,$num_seqs,$msa_len);
 	@MSA = @{$msa_ref};
 	@Disagreements = @{$DisagreementsRef};
+	$msa_len = $new_len;
     }
 
 


### PR DESCRIPTION
… in a

smaller scope, rather than writing a new length to the actual msa_len variable