### PR TITLE
Intra-species MSAs no longer have an extra space between the end

### DIFF
--- a/src/MapsToMSAs.pl
+++ b/src/MapsToMSAs.pl
@@ -967,7 +967,7 @@ sub WriteMSAToFile
 	    print $outf "\n" if (($j+1) % 60 == 0);
 	}
 	print $outf "\n" if ($msa_len % 60);
-	print $outf "\n";
+	#print $outf "\n";
     }
     close($outf);
 


### PR DESCRIPTION
of one sequence and the start of the next